### PR TITLE
Enable metrics for nic

### DIFF
--- a/configuration/sandpit/level0/launchpad/diagnostics_definition.tfvars
+++ b/configuration/sandpit/level0/launchpad/diagnostics_definition.tfvars
@@ -95,7 +95,7 @@ diagnostics_definition = {
     categories = {
       metric = [
         #["Category name",  "Diagnostics Enabled(true/false)", "Retention Enabled(true/false)", Retention_period]
-        ["AllMetrics", false, false, 7],
+        ["AllMetrics", true, false, 7],
       ]
     }
   }


### PR DESCRIPTION
This fixes an issue where the sandpit launchpad fails to apply with the error `Error: At least one `log` or `metric` must be enabled`

# [Issue-id 10](https://github.com/Azure/caf-terraform-landingzones-starter/issues/10)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Enable metrics for nic to get past error.
Fixes #10 
## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Deploy sandpit launchpad as per docs.