### PR TITLE
Custom role conflict - use prefix

### DIFF
--- a/configuration/sandpit/level0/azure_devops/configuration.tfvars
+++ b/configuration/sandpit/level0/azure_devops/configuration.tfvars
@@ -101,7 +101,7 @@ custom_role_definitions = {
 
   caf-azdo-to-azure-subscription = {
     name        = "caf-azure-devops-TO-azure-subscription"
-    useprefix   = false
+    useprefix   = true
     description = "CAF Custom role for service principal in Azure Devops to access resources"
     permissions = {
       actions = [


### PR DESCRIPTION
Quickfix for custom role creation issue.
Set ```useprefix   = true``` as it should be.
