### PR TITLE
Fix keyvault access policy config key and landingzone level

### DIFF
--- a/configuration/sandpit/level1/gitops/azure_devops/landingzone.tfvars
+++ b/configuration/sandpit/level1/gitops/azure_devops/landingzone.tfvars
@@ -1,7 +1,7 @@
 landingzone = {
   backend_type        = "azurerm"
   global_settings_key = "launchpad"
-  level               = "level0"
+  level               = "level1"
   key                 = "azdo-contoso_demo"
   tfstates = {
     launchpad = {
@@ -44,35 +44,35 @@ keyvaults = {
 keyvault_access_policies_azuread_apps = {
   level0 = {
     contoso_demo = {
-      lz_key             = "launchpad"
+      keyvault_lz_key    = "launchpad"
       azuread_app_key    = "contoso_demo"
       secret_permissions = ["Get", "List"]
     }
   }
   level1 = {
     contoso_demo = {
-      lz_key             = "launchpad"
+      keyvault_lz_key    = "launchpad"
       azuread_app_key    = "contoso_demo"
       secret_permissions = ["Get", "List"]
     }
   }
   level2 = {
     contoso_demo = {
-      lz_key             = "launchpad"
+      keyvault_lz_key    = "launchpad"
       azuread_app_key    = "contoso_demo"
       secret_permissions = ["Get", "List"]
     }
   }
   level3 = {
     contoso_demo = {
-      lz_key             = "launchpad"
+      keyvault_lz_key    = "launchpad"
       azuread_app_key    = "contoso_demo"
       secret_permissions = ["Get", "List"]
     }
   }
   level4 = {
     contoso_demo = {
-      lz_key             = "launchpad"
+      keyvault_lz_key    = "launchpad"
       azuread_app_key    = "contoso_demo"
       secret_permissions = ["Get", "List"]
     }


### PR DESCRIPTION
# [64](https://github.com/Azure/caf-terraform-landingzones-starter/issues/64)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The keyvault_access_policies_azuread_apps currently references the incorrect config key and the azure_devops template is configured at the incorrect level.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing

Running terraform plan should now produce no errors and the apply should now run without error.
